### PR TITLE
add expected output file for regtest ww3_tp2.5

### DIFF
--- a/.github/workflows/regtest_gnu.yml
+++ b/.github/workflows/regtest_gnu.yml
@@ -111,8 +111,6 @@ jobs:
           ./bin/run_cmake_test -o all -S -T -s PR1_MPI -w work_PR1_MPI -f -p mpirun -n 24 ../model ww3_tp2.5
           cd ww3_tp2.5
           ls -l
-          cd ww3_tp2.5
-          ls -l
           cd work_PR1_MPI
           pwd
           ls -l

--- a/.github/workflows/regtest_gnu.yml
+++ b/.github/workflows/regtest_gnu.yml
@@ -114,7 +114,7 @@ jobs:
           cd work_PR1_MPI
           pwd
           ls -l
-          /usr/local/netcdf-c-4.9.3-dev/bin/ncdump -h out_pnt.ww3.nc > ncdump_out.txt
+          ncdump -h out_pnt.ww3.nc > ncdump_out.txt
           cat ncdump_out.txt
           pwd
           cat ${GITHUB_WORKSPACE}/ww3/regtests/ww3_tp2.5/out_pnt_ncdump.txt

--- a/.github/workflows/regtest_gnu.yml
+++ b/.github/workflows/regtest_gnu.yml
@@ -108,13 +108,19 @@ jobs:
           make -j2 VERBOSE=1
           ${GITHUB_WORKSPACE}/ww3/model/bin/ww3_from_ftp.sh          
           cd ${GITHUB_WORKSPACE}/ww3/regtests
-          ./bin/run_cmake_test -o all -S -T -s PR1_MPI -w work_PR1_MPI -f -p mpirun -n 24 ../model ww3_tp2.4
-          cd ww3_tp2.4
-          cd ..
           ./bin/run_cmake_test -o all -S -T -s PR1_MPI -w work_PR1_MPI -f -p mpirun -n 24 ../model ww3_tp2.5
           cd ww3_tp2.5
           ls -l
-          
+          cd ww3_tp2.5
+          ls -l
+          cd work_PR1_MPI
+          pwd
+          ls -l
+          /usr/local/netcdf-c-4.9.3-dev/bin/ncdump -h out_pnt.ww3.nc > ncdump_out.txt
+          cat ncdump_out.txt
+          pwd
+          cat ${GITHUB_WORKSPACE}/ww3/regtests/ww3_tp2.5/out_pnt_ncdump.txt
+          cmp ${GITHUB_WORKSPACE}/ww3/regtests/ww3_tp2.5/out_pnt_ncdump.txt ncdump_out.txt          
         
 
 

--- a/regtests/unittests/test_io.F90
+++ b/regtests/unittests/test_io.F90
@@ -102,7 +102,7 @@ program test_io
   if (iotest .ne. 0) stop 100
   print *, 'OK!'
   
-  ! print *, 'testing reading the WW3 binary point file in netCDF...'
+  print *, 'testing reading the WW3 binary point file in netCDF...'
   ! call w3iopon('READ', ndsop, iotest)
   ! print *, iotest
   ! if (iotest .ne. 0) stop 100

--- a/regtests/ww3_tp2.5/out_pnt_ncdump.txt
+++ b/regtests/ww3_tp2.5/out_pnt_ncdump.txt
@@ -1,0 +1,33 @@
+netcdf out_pnt.ww3 {
+dimensions:
+	NOPTS = 1 ;
+	NSPEC = 36 ;
+	VSIZE = 2 ;
+	NAMELEN = 40 ;
+	GRDIDLEN = 13 ;
+	TIME = UNLIMITED ; // (13 currently)
+variables:
+	int NK ;
+	int NTH ;
+	float PTLOC(NOPTS, VSIZE) ;
+	char PTNME(NOPTS, NAMELEN) ;
+	int TIME(TIME, VSIZE) ;
+	int IW(TIME, NOPTS) ;
+	int II(TIME, NOPTS) ;
+	int IL(TIME, NOPTS) ;
+	float DPO(TIME, NOPTS) ;
+	float WAO(TIME, NOPTS) ;
+	float WDO(TIME, NOPTS) ;
+	float ASO(TIME, NOPTS) ;
+	float CAO(TIME, NOPTS) ;
+	float CDO(TIME, NOPTS) ;
+	float ICEO(TIME, NOPTS) ;
+	float ICEHO(TIME, NOPTS) ;
+	float ICEFO(TIME, NOPTS) ;
+	char GRDID(TIME, NOPTS, GRDIDLEN) ;
+	float SPCO(TIME, NOPTS, NSPEC) ;
+
+// global attributes:
+		:title = "WAVEWATCH III POINT OUTPUT FILE" ;
+		:version = "2021-04-06" ;
+}


### PR DESCRIPTION
In this PR I add an expected output file, the ncdump -h output for the out_pnt.ww3.nc file produced in the regtest.